### PR TITLE
Github-actions: run tests in MSYS2

### DIFF
--- a/.github/workflows/build-msys2.yml
+++ b/.github/workflows/build-msys2.yml
@@ -36,6 +36,9 @@ jobs:
     - name: Build
       run:
         ./scripts/ci/msys2/build.sh
+    - name: Run tests
+      run:
+        ./scripts/ci/msys2/run_tests.sh
     - name: Upload Libs
       run: scripts/ci/upload_of_lib.sh;
       env:


### PR DESCRIPTION
Run MSYS2 tests.
Fix MINGW32 build (MSYSTEM declared in env: section was overriden by msys2setup)